### PR TITLE
Add parameter for bootstrapping Python

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -277,6 +277,7 @@ export const bootstrapFromEmpackPackedEnvironment = async (
       prefix
     );
   }
+
   if (packages?.length) {
     let sharedLibs = await Promise.all(
       packages.map(pkg => {
@@ -298,6 +299,11 @@ export const bootstrapFromEmpackPackedEnvironment = async (
       loadShareLibs(packages, sharedLibs, prefix, Module);
     }
   }
+
+  if (bootstrapPython && pythonPackage && pythonVersion) {
+    globalThis.Module.init_phase_2(prefix, pythonVersion, verbose);
+  }
+
   return packagesData;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -225,6 +225,7 @@ const checkCondaMetaFile = (files: FilesData): boolean => {
   });
   return isCondaMetaFile;
 };
+
 const initPrimaryPhase = async (
   pythonPackage: IEmpackEnvMetaPkg,
   pythonVersion: number[],
@@ -249,7 +250,8 @@ export const bootstrapFromEmpackPackedEnvironment = async (
   verbose: boolean = true,
   skipLoadingSharedLibs: boolean = false,
   Module: any,
-  pkgRootUrl: string
+  pkgRootUrl: string,
+  bootstrapPython = false
 ): Promise<IPackagesInfo> => {
   if (verbose) {
     console.log('fetching packages.json from', packagesJsonUrl);
@@ -264,7 +266,7 @@ export const bootstrapFromEmpackPackedEnvironment = async (
   const untarjsReady = initUntarJS();
   const untarjs = await untarjsReady;
 
-  if (pythonPackage && pythonVersion) {
+  if (bootstrapPython && pythonPackage && pythonVersion) {
     await initPrimaryPhase(
       pythonPackage,
       pythonVersion,


### PR DESCRIPTION
This is to prevent bootstrapping Python when e.g. Python is installed but we're using a xeus-r kernel in jupyterlite-xeus