### PR TITLE
Split bootstrap of the filesystem / Python interpreter / loading shared logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,32 +2,4 @@
 
 Installing conda packages into a browser
 
-## Using
-
-This package has 2 methods:
-- `installCondaPackage(prefix, url, Module.FS, untarjs, verbose)` - downloading one conda package and saving it into a browser. It returns shared libs if a package has them.
-
-- `bootstrapFromEmpackPackedEnvironment( packagesJsonUrl, verbose, skipLoadingSharedLibs,Module, pkgRootUrl)` - downloading empack_env_meta.json and installing all conda packages from this file.
-
-The example of using:
-
-```ts
-import {
-  bootstrapFromEmpackPackedEnvironment,
-  IPackagesInfo
-} from '@emscripten-forge/mambajs';
-
- const packagesJsonUrl = `http://localhost:8888/empack_env_meta.json`;
- const pkgRootUrl = 'kernel/kernel_packages';
- cosnt verbose = true;
-
- let packageData: IPackagesInfo = {};
- packageData = await bootstrapFromEmpackPackedEnvironment(
-    packagesJsonUrl,
-    verbose,
-    false,
-    Module,
-    pkgRootUrl
-);
-
-```
+This is still in progress, APIs are subject to change quickly

--- a/src/dynload/dynload.js
+++ b/src/dynload/dynload.js
@@ -43,7 +43,7 @@ function isInSharedLibraryPath(prefix, libPath){
 
 export async function loadDynlibsFromPackage(
     prefix,
-    pkg_file_name,
+    pkgName,
     dynlibPaths,
     Module
   ) {
@@ -55,9 +55,7 @@ export async function loadDynlibsFromPackage(
     else{
         var sitepackages = `${prefix}/lib/python3.11/site-packages`
     }
-    const auditWheelLibDir = `${sitepackages}/${
-        pkg_file_name.split("-")[0]
-    }.libs`;
+    const auditWheelLibDir = `${sitepackages}/${pkgName}.libs`;
 
     // This prevents from reading large libraries multiple times.
     const readFileMemoized = memoize(Module.FS.readFile);

--- a/src/dynload/dynload.js
+++ b/src/dynload/dynload.js
@@ -44,7 +44,6 @@ function isInSharedLibraryPath(prefix, libPath){
 export async function loadDynlibsFromPackage(
     prefix,
     pkg_file_name,
-    pkg_is_shared_library,
     dynlibPaths,
     Module
   ) {
@@ -62,35 +61,22 @@ export async function loadDynlibsFromPackage(
 
     // This prevents from reading large libraries multiple times.
     const readFileMemoized = memoize(Module.FS.readFile);
-    const forceGlobal = !!pkg_is_shared_library;
-
-
 
     let dynlibs = [];
 
-
-    if (forceGlobal) {
-      dynlibs = Object.keys(dynlibPaths).map((path) =>{
-        return {
-          path: path,
-          global: true,
-        };
-      });
-    } else {
-      const globalLibs = calculateGlobalLibs(
+    const globalLibs = calculateGlobalLibs(
         dynlibPaths,
         readFileMemoized,
         Module
-      );
+    );
 
-      dynlibs = Object.keys(dynlibPaths).map((path) =>{
+    dynlibs = dynlibPaths.map((path) =>{
         const global = globalLibs.has(Module.PATH.basename(path));
         return {
-          path: path,
-          global: global || !! pkg_is_shared_library || isInSharedLibraryPath(prefix, path) || path.startsWith(auditWheelLibDir),
+            path: path,
+            global: global || isInSharedLibraryPath(prefix, path) || path.startsWith(auditWheelLibDir),
         };
-      });
-    }
+    });
 
     dynlibs.sort((lib1, lib2) => Number(lib2.global) - Number(lib1.global));
     for (const { path, global } of dynlibs) {
@@ -172,7 +158,7 @@ function calculateGlobalLibs(
 
     const globalLibs = new Set();
 
-    Object.keys(libs).map((lib) => {
+    libs.map((lib) => {
         const binary = readFile(lib);
         const needed = Module.getDylinkMetadata(binary).neededDynlibs;
         needed.forEach((lib) => {
@@ -193,9 +179,9 @@ async function loadDynlib(prefix, lib, global, searchDirs, readFileFunc, Module)
     if (searchDirs === undefined) {
         searchDirs = [];
     }
- 
+
     const releaseDynlibLock = await acquireDynlibLock();
-    
+
     try {
         const fs = createDynlibFS(prefix, lib, searchDirs, readFileFunc, Module);
 

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -14,6 +14,16 @@ export interface IEmpackEnvMeta {
   packages: IEmpackEnvMetaPkg[];
 }
 
+/**
+ * Shared libraries. list of .so files
+ */
+export type TSharedLibs = string[];
+
+/**
+ * Shared libraries. A map package name -> list of .so files
+ */
+export type TSharedLibsMap = { [pkgName:string]: TSharedLibs };
+
 // export async function fetchJson(url: string): Promise<any> {
 //   let response = await fetch(url);
 //   if (!response.ok) {
@@ -27,17 +37,28 @@ export function getParentDirectory(filePath: string): string {
   return filePath.substring(0, filePath.lastIndexOf('/'));
 }
 
-export function getSharedLibs(files: FilesData, prefix: string): FilesData {
-  let sharedLibs: FilesData = {};
+export function getSharedLibs(files: FilesData, prefix: string): TSharedLibs {
+  let sharedLibs: TSharedLibs = [];
 
   Object.keys(files).map(file => {
-    if (file.endsWith('.so') || file.includes('.so.')) {
-      sharedLibs[`${prefix}/${file}`] = files[file];
+    if ((file.endsWith('.so') || file.includes('.so.')) && checkWasmMagicNumber(files[file])) {
+      sharedLibs.push(`${prefix}/${file}`);
     }
   });
 
   return sharedLibs;
 }
+
+export function checkWasmMagicNumber(uint8Array: Uint8Array): boolean {
+  const WASM_MAGIC_NUMBER = [0x00, 0x61, 0x73, 0x6d];
+
+  return (
+    uint8Array[0] === WASM_MAGIC_NUMBER[0] &&
+    uint8Array[1] === WASM_MAGIC_NUMBER[1] &&
+    uint8Array[2] === WASM_MAGIC_NUMBER[2] &&
+    uint8Array[3] === WASM_MAGIC_NUMBER[3]
+  );
+};
 
 export function isCondaMeta(files: FilesData): boolean {
   let isCondaMetaFile = false;
@@ -81,33 +102,13 @@ export function saveFiles(FS: any, files: FilesData, prefix: string): void {
   }
 }
 
-export async function bootstrapPythonPackage(
-  pythonPackage: IEmpackEnvMetaPkg,
-  pythonVersion: number[],
-  verbose: boolean,
-  untarjs: IUnpackJSAPI,
-  Module: any,
-  pkgRootUrl: string,
-  prefix: string
-): Promise<void> {
-  let url = pythonPackage.url
-    ? pythonPackage.url
-    : `${pkgRootUrl}/${pythonPackage.filename}`;
-  if (verbose) {
-    console.log(`Installing a python package from ${url}`);
-  }
-  await installCondaPackage(prefix, url, Module.FS, untarjs, verbose);
-  await Module.init_phase_1(prefix, pythonVersion, verbose);
-}
-
 export async function installCondaPackage(
   prefix: string,
   url: string,
   FS: any,
   untarjs: IUnpackJSAPI,
   verbose: boolean
-): Promise<FilesData> {
-  let sharedLibs: FilesData = {};
+): Promise<TSharedLibs> {
   if (!url) {
     throw new Error(`There is no file in ${url}`);
   }
@@ -159,10 +160,12 @@ export async function installCondaPackage(
   if (prefix === '/') {
     newPrefix = '';
   }
+
   if (Object.keys(installedFiles).length !== 0) {
-    sharedLibs = getSharedLibs(installedFiles, newPrefix);
+    return getSharedLibs(installedFiles, newPrefix);
   }
-  return sharedLibs;
+
+  return [];
 }
 
 export function saveCondaMetaFile(

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -24,15 +24,6 @@ export type TSharedLibs = string[];
  */
 export type TSharedLibsMap = { [pkgName: string]: TSharedLibs };
 
-// export async function fetchJson(url: string): Promise<any> {
-//   let response = await fetch(url);
-//   if (!response.ok) {
-//     throw new Error(`HTTP error! status: ${response.status}`);
-//   }
-//   let json = await response.json();
-//   return json;
-// }
-
 export function getParentDirectory(filePath: string): string {
   return filePath.substring(0, filePath.lastIndexOf('/'));
 }
@@ -72,22 +63,6 @@ export function isCondaMeta(files: FilesData): boolean {
     }
   });
   return isCondaMetaFile;
-}
-
-export function getPythonVersion(
-  packages: IEmpackEnvMetaPkg[]
-): number[] | undefined {
-  let pythonPackage: IEmpackEnvMetaPkg | undefined = undefined;
-  for (let i = 0; i < packages.length; i++) {
-    if (packages[i].name == 'python') {
-      pythonPackage = packages[i];
-      break;
-    }
-  }
-
-  if (pythonPackage) {
-    return pythonPackage.version.split('.').map(x => parseInt(x));
-  }
 }
 
 export function saveFiles(FS: any, files: FilesData, prefix: string): void {

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -22,7 +22,7 @@ export type TSharedLibs = string[];
 /**
  * Shared libraries. A map package name -> list of .so files
  */
-export type TSharedLibsMap = { [pkgName:string]: TSharedLibs };
+export type TSharedLibsMap = { [pkgName: string]: TSharedLibs };
 
 // export async function fetchJson(url: string): Promise<any> {
 //   let response = await fetch(url);
@@ -41,7 +41,10 @@ export function getSharedLibs(files: FilesData, prefix: string): TSharedLibs {
   let sharedLibs: TSharedLibs = [];
 
   Object.keys(files).map(file => {
-    if ((file.endsWith('.so') || file.includes('.so.')) && checkWasmMagicNumber(files[file])) {
+    if (
+      (file.endsWith('.so') || file.includes('.so.')) &&
+      checkWasmMagicNumber(files[file])
+    ) {
       sharedLibs.push(`${prefix}/${file}`);
     }
   });
@@ -58,7 +61,7 @@ export function checkWasmMagicNumber(uint8Array: Uint8Array): boolean {
     uint8Array[2] === WASM_MAGIC_NUMBER[2] &&
     uint8Array[3] === WASM_MAGIC_NUMBER[3]
   );
-};
+}
 
 export function isCondaMeta(files: FilesData): boolean {
   let isCondaMetaFile = false;

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -9,14 +9,19 @@ export interface IEmpackEnvMetaPkg {
   url: string;
 }
 
-export async function fetchJson(url: string): Promise<any> {
-  let response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
-  }
-  let json = await response.json();
-  return json;
+export interface IEmpackEnvMeta {
+  prefix: string;
+  packages: IEmpackEnvMetaPkg[];
 }
+
+// export async function fetchJson(url: string): Promise<any> {
+//   let response = await fetch(url);
+//   if (!response.ok) {
+//     throw new Error(`HTTP error! status: ${response.status}`);
+//   }
+//   let json = await response.json();
+//   return json;
+// }
 
 export function getParentDirectory(filePath: string): string {
   return filePath.substring(0, filePath.lastIndexOf('/'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,5 @@
 import { initUntarJS, IUnpackJSAPI } from '@emscripten-forge/untarjs';
-import {
-  IEmpackEnvMeta,
-  installCondaPackage,
-  TSharedLibsMap
-} from './helper';
+import { IEmpackEnvMeta, installCondaPackage, TSharedLibsMap } from './helper';
 import { loadDynlibsFromPackage } from './dynload/dynload';
 
 export interface IBootstrapEmpackPackedEnvironmentOptions {
@@ -34,7 +30,7 @@ export interface IBootstrapEmpackPackedEnvironmentOptions {
 }
 
 /**
- * Bootstrap a filesystem from an empack lock file
+ * Bootstrap a filesystem from an empack lock file. And return the installed shared libs.
  *
  * @param options
  * @returns The installed shared libraries as a TSharedLibs

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import {
 } from './helper';
 import { loadDynlibsFromPackage } from './dynload/dynload';
 
+export * from './helper';
+
 export function getPythonVersion(
   packages: IEmpackEnvMetaPkg[]
 ): number[] | undefined {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,8 @@
 import { initUntarJS, IUnpackJSAPI } from '@emscripten-forge/untarjs';
 import {
-  TSharedLibs,
-  TSharedLibsMap,
   IEmpackEnvMeta,
-  installCondaPackage
+  installCondaPackage,
+  TSharedLibsMap
 } from './helper';
 import { loadDynlibsFromPackage } from './dynload/dynload';
 
@@ -40,7 +39,9 @@ export interface IBootstrapEmpackPackedEnvironmentOptions {
  * @param options
  * @returns The installed shared libraries as a TSharedLibs
  */
-export const bootstrapEmpackPackedEnvironment = async (options: IBootstrapEmpackPackedEnvironmentOptions): Promise<TSharedLibsMap> => {
+export const bootstrapEmpackPackedEnvironment = async (
+  options: IBootstrapEmpackPackedEnvironmentOptions
+): Promise<TSharedLibsMap> => {
   const { empackEnvMeta, pkgRootUrl, Module, verbose } = options;
 
   let untarjs: IUnpackJSAPI;
@@ -105,8 +106,16 @@ export interface IBootstrapPythonOptions {
  */
 export async function bootstrapPython(options: IBootstrapPythonOptions) {
   // Assuming these are defined by pyjs
-  await options.Module.init_phase_1(options.prefix, options.pythonVersion, options.verbose);
-  options.Module.init_phase_2(options.prefix, options.pythonVersion, options.verbose);
+  await options.Module.init_phase_1(
+    options.prefix,
+    options.pythonVersion,
+    options.verbose
+  );
+  options.Module.init_phase_2(
+    options.prefix,
+    options.pythonVersion,
+    options.verbose
+  );
 }
 
 export interface ILoadSharedLibsOptions {
@@ -127,7 +136,7 @@ export interface ILoadSharedLibsOptions {
 }
 
 export async function loadShareLibs(
-  options: ILoadSharedLibsOptions,
+  options: ILoadSharedLibsOptions
 ): Promise<void[]> {
   const { sharedLibs, prefix, Module } = options;
 
@@ -145,7 +154,7 @@ export async function loadShareLibs(
       }
     })
   );
-};
+}
 
 const waitRunDependencies = (Module: any): Promise<void> => {
   const promise = new Promise<void>(r => {
@@ -159,4 +168,3 @@ const waitRunDependencies = (Module: any): Promise<void> => {
   Module.removeRunDependency('dummy');
   return promise;
 };
-


### PR DESCRIPTION
As the title says. This also adds some docstrings + some code cleanup

Fix https://github.com/emscripten-forge/mambajs/issues/8