### PR TITLE
fix:-duplication of package not found warning

### DIFF
--- a/src/solverpip.ts
+++ b/src/solverpip.ts
@@ -129,10 +129,10 @@ function getSuitableVersion(
   }
 }
 
-const warnedPackages = new Set();
 
 async function processRequirement(
   requirement: ISpec,
+  warnedPackages: Set<string>,
   pipSolvedPackages: ISolvedPackages,
   pipInstalledPackages: Set<string>,
   installedPackages: Set<string>,
@@ -187,6 +187,7 @@ async function processRequirement(
     ) {
       await processRequirement(
         parsedRequirement,
+        warnedPackages,
         pipSolvedPackages,
         pipInstalledPackages,
         installedPackages,
@@ -223,11 +224,13 @@ export async function solvePip(
     installedPackages.add(pipPackageName);
   }
 
+  const warnedPackages = new Set<string>();
   const pipSolvedPackages: ISolvedPackages = {};
   const pipInstalledPackages = new Set<string>();
   for (const spec of specs) {
     await processRequirement(
       spec,
+      warnedPackages,
       pipSolvedPackages,
       pipInstalledPackages,
       installedPackages,

--- a/src/solverpip.ts
+++ b/src/solverpip.ts
@@ -129,6 +129,8 @@ function getSuitableVersion(
   }
 }
 
+const warnedPackages = new Set();
+
 async function processRequirement(
   requirement: ISpec,
   pipSolvedPackages: ISolvedPackages,
@@ -142,9 +144,12 @@ async function processRequirement(
 
   const solved = getSuitableVersion(pkgMetadata, requirement.constraints);
   if (!solved) {
-    logger?.warn(
-      `Cannot install ${requirement.package} from PyPi. Please make sure to install it from conda-forge or emscripten-forge!`
-    );
+    if (!warnedPackages.has(requirement.package)) {
+      logger?.warn(
+        `Cannot install ${requirement.package} from PyPi. Please make sure to install it from conda-forge or emscripten-forge!`
+      );
+      warnedPackages.add(requirement.package);
+    }
 
     return;
   }


### PR DESCRIPTION
## Summary
This PR fixes the issue where the same package "not found" warning was logged multiple times.

## Changes
- Introduced a `warnedPackages` Set to track packages that have already triggered a warning.
- Prevents duplicate warnings by checking before logging.

closes #49
