### PR TITLE
Parsing '%conda remove' and '%pip uninstall' commands

### DIFF
--- a/packages/mambajs-core/src/parser.ts
+++ b/packages/mambajs-core/src/parser.ts
@@ -150,6 +150,7 @@ function parseRemoveCommand(
   if (input) {
     if (isPipCommand) {
       command.data = getPipUnInstallParameters(input, logger);
+      command.type = 'uninstall';
     } else {
       command.data = getCondaRemoveCommandParameters(input, logger);
     }


### PR DESCRIPTION
This PR has the solution of https://github.com/emscripten-forge/mambajs/issues/94
This PR has next changes:
- refactoring the command parser
- adding parsing "%conda remove" and "pip uninstall" commands  which is needed for the logic of removing packages from an environment
Results:
![image](https://github.com/user-attachments/assets/97e8bf46-0105-474c-8621-1a1701c0485c)
![image](https://github.com/user-attachments/assets/201b1e71-acef-4104-9606-4cf97b80bac3)
