### PR TITLE
Call the solver without deleted packages

### DIFF
--- a/packages/mambajs/src/index.ts
+++ b/packages/mambajs/src/index.ts
@@ -103,7 +103,7 @@ export async function solve(
   };
 }
 
-export async function solveEnv(
+export async function solveWithoutPackages(
   specs: string[],
   pipSpecs: string[],
   installedPackages: ISolvedPackages,

--- a/packages/mambajs/src/index.ts
+++ b/packages/mambajs/src/index.ts
@@ -106,38 +106,38 @@ export async function solve(
 export async function solveWithoutPackages(
   specs: string[],
   pipSpecs: string[],
+  packagesList: string[],
   installedPackages: ISolvedPackages,
   logger: ILogger
 ) {
-  let newSpecs: string[] = getSpecs(installedPackages, specs);
-  let newPipSpecs: string[] = getSpecs(installedPackages, pipSpecs);
+  let newSpecs: string[] = removePackagesFromTheList(packagesList, specs);
+  let newPipSpecs: string[] = removePackagesFromTheList(packagesList, pipSpecs);
 
   return await solve({
     ymlOrSpecs: newSpecs,
     installedPackages: installedPackages,
     pipSpecs: newPipSpecs,
-    channels: [], //?
+    channels: [],
     logger: logger
   });
 }
 
-function getSpecs(installedPackages: ISolvedPackages, specs: string[]) {
+function removePackagesFromTheList(packageList: string[], specs: string[]) {
   const newSpecs: string[] = [];
   if (specs.length) {
-    Object.keys(installedPackages).forEach(filename => {
-      const pkg = installedPackages[filename];
+    packageList.forEach((name:string) => {
       let isInSpecs = false;
       specs.filter((spec: string) => {
         const nameMatch = getPackageName(spec);
         if (nameMatch !== null) {
           const packageName = nameMatch[1];
-          if (pkg.name === packageName) {
+          if (name === packageName) {
             isInSpecs = true;
           }
         }
       });
       if (!isInSpecs) {
-        newSpecs.push(pkg.name);
+        newSpecs.push(name);
       }
     });
   }

--- a/packages/mambajs/src/solverpip.ts
+++ b/packages/mambajs/src/solverpip.ts
@@ -86,9 +86,11 @@ function resolveVersion(availableVersions: string[], constraint: string) {
     ? stableVersions[0]
     : validVersions[0] || undefined;
 }
-
+export function getPackageName(name: string) {
+  return name.match(/^([a-zA-Z0-9_-]+)/);
+}
 function parsePyPiRequirement(requirement: string): ISpec | null {
-  const nameMatch = requirement.match(/^([a-zA-Z0-9_-]+)/);
+  const nameMatch = getPackageName(requirement);
 
   if (!nameMatch) {
     return null;


### PR DESCRIPTION
This PR is still under progress and can be changed and it has the solution of https://github.com/emscripten-forge/mambajs/issues/96
This PR includes the logic that removes requested packages for deleting from specs and pipSpecs and runs the solver with new data