### PR TITLE
Update and export types for depends, subdir and command type

### DIFF
--- a/packages/mambajs-core/src/helper.ts
+++ b/packages/mambajs-core/src/helper.ts
@@ -30,6 +30,8 @@ export interface IEmpackEnvMetaPkg {
   filename_stem: string;
   filename: string;
   url: string;
+  depends: [],
+  subdir: string
 }
 
 export interface IEmpackEnvMeta {

--- a/packages/mambajs-core/src/parser.ts
+++ b/packages/mambajs-core/src/parser.ts
@@ -5,7 +5,7 @@ export interface IParsedCommand {
   data: IInstallationCommandOptions | IUninstallationCommandOptions | null;
 }
 
-type CommandsName = 'install' | 'list' | 'remove' | 'uninstall';
+export type CommandsName = 'install' | 'list' | 'remove' | 'uninstall';
 
 export interface ICommandData {
   commands: IParsedCommand[];


### PR DESCRIPTION
Now empack_env_meta.json file includes depends and subdir, so we need to update IEmpackEnvMetaPkg for https://github.com/jupyterlite/xeus/pull/241 and return command types 