### PR TITLE
Fix removing packages from Emscripten FS

### DIFF
--- a/packages/mambajs-core/src/helper.ts
+++ b/packages/mambajs-core/src/helper.ts
@@ -37,6 +37,7 @@ export interface IEmpackEnvMetaPkg {
 export interface IEmpackEnvMeta {
   prefix: string;
   packages: IEmpackEnvMetaPkg[];
+  specs?: string[]
 }
 
 /**
@@ -203,7 +204,7 @@ export function saveFilesIntoEmscriptenFS(
   }
 }
 
-export function removeFilesFromEmscriptenFS(FS: any, paths: any): void {
+export function removeFilesFromEmscriptenFS(FS: any, paths: any, logger?: ILogger): void {
   try {
     const pwd = FS.cwd();
     FS.chdir('/');
@@ -216,6 +217,8 @@ export function removeFilesFromEmscriptenFS(FS: any, paths: any): void {
         } else {
           FS.unlink(path);
         }
+      }else {
+         logger?.log(`Path ${path} does not exist`);
       }
     });
     FS.chdir(pwd);

--- a/packages/mambajs-core/src/helper.ts
+++ b/packages/mambajs-core/src/helper.ts
@@ -30,14 +30,14 @@ export interface IEmpackEnvMetaPkg {
   filename_stem: string;
   filename: string;
   url: string;
-  depends: [],
-  subdir: string
+  depends: [];
+  subdir: string;
 }
 
 export interface IEmpackEnvMeta {
   prefix: string;
   packages: IEmpackEnvMetaPkg[];
-  specs?: string[]
+  specs?: string[];
 }
 
 /**
@@ -204,7 +204,11 @@ export function saveFilesIntoEmscriptenFS(
   }
 }
 
-export function removeFilesFromEmscriptenFS(FS: any, paths: any, logger?: ILogger): void {
+export function removeFilesFromEmscriptenFS(
+  FS: any,
+  paths: any,
+  logger?: ILogger
+): void {
   try {
     const pwd = FS.cwd();
     FS.chdir('/');
@@ -217,8 +221,8 @@ export function removeFilesFromEmscriptenFS(FS: any, paths: any, logger?: ILogge
         } else {
           FS.unlink(path);
         }
-      }else {
-         logger?.log(`Path ${path} does not exist`);
+      } else {
+        logger?.log(`Path ${path} does not exist`);
       }
     });
     FS.chdir(pwd);

--- a/packages/mambajs-core/src/index.ts
+++ b/packages/mambajs-core/src/index.ts
@@ -268,7 +268,7 @@ export const removePackagesFromEmscriptenFS = async (
       });
     }
     if (!packages) {
-      throw new Error(`There are no pathes for ${filename}`);
+      throw new Error(`There are no paths for ${filename}`);
     }
     removeFilesFromEmscriptenFS(Module.FS, packages, logger);
     delete newPath[filename];

--- a/packages/mambajs-core/src/index.ts
+++ b/packages/mambajs-core/src/index.ts
@@ -241,15 +241,17 @@ export interface IRemovePackagesFromEnvOptions {
  */
 export const removePackagesFromEmscriptenFS = async (
   options: IRemovePackagesFromEnvOptions
-): Promise<void> => {
+): Promise<any> => {
   const { removedPackages, Module, paths, logger } = options;
+  const newPath = {...paths}; 
   Object.keys(removedPackages).map(filename => {
     const pkg = removedPackages[filename];
     logger?.log(`Uninstalling ${pkg.name} ${pkg.version}`);
-    const packages = paths[filename];
-    removeFilesFromEmscriptenFS(Module.FS, packages);
-    delete paths[filename];
+    const packages = newPath[filename];
+    removeFilesFromEmscriptenFS(Module.FS, packages, logger);
+    delete newPath[filename];
   });
+  return newPath;
 };
 
 export interface IBootstrapPythonOptions {

--- a/packages/mambajs/package.json
+++ b/packages/mambajs/package.json
@@ -37,7 +37,7 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "@conda-org/rattler": "^0.3.0",
+    "@conda-org/rattler": "^0.3.1",
     "@emscripten-forge/mambajs-core": "^0.13.0",
     "yaml": "^2.7.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@conda-org/rattler@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@conda-org/rattler@npm:0.3.0"
-  checksum: 10c0/af9d03c8bc63694c654ea950df4f3e2044c1d2205e258e4e739a9c9971898a40e4fba627066a3e6683c2a3e7bc337b1c167932901845ddd9904a7417bf3c0e92
+"@conda-org/rattler@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@conda-org/rattler@npm:0.3.1"
+  checksum: 10c0/882dda8d0d420a61d19ac95d551469d3da8f7cf1ea59bcf08579d4bda42b0a00d6d64a1df0b898cfccef4b38123ca26b8088f8ec96298cec937fcff05a253376
   languageName: node
   linkType: hard
 
@@ -98,7 +98,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@emscripten-forge/mambajs@workspace:packages/mambajs"
   dependencies:
-    "@conda-org/rattler": "npm:^0.3.0"
+    "@conda-org/rattler": "npm:^0.3.1"
     "@emscripten-forge/mambajs-core": "npm:^0.13.0"
     "@esbuild-plugins/node-globals-polyfill": "npm:^0.2.3"
     "@esbuild-plugins/node-modules-polyfill": "npm:^0.2.2"


### PR DESCRIPTION
This PR has the solution of https://github.com/emscripten-forge/mambajs/issues/101
This PR fixes 2 bugs:
- `path` object mutated its data and it was used in 3 places in jupyterlite/xeus. This mutation effects how packages are deleted. For example, when we tried to remove ipycanvas, the issue was that we could still use this package after. So, after this fix, if we delete some package we cannot use it.
- removing packages were not correct because if the `path `object had a filename with different extentions than package data after resolving step, but package parameters (a name, a version, a build) were the same, then a package with its files were not removed. After fix, it checks if we have package data in a `path key` and if so, we can get access to packages paths 