### PR TITLE
Add packageNameFromSpec method

### DIFF
--- a/packages/mambajs-core/src/index.ts
+++ b/packages/mambajs-core/src/index.ts
@@ -503,3 +503,14 @@ export function sort(installed: ISolvedPackages): Map<string, ISolvedPackage> {
 
   return new Map(sorted);
 }
+
+export function packageNameFromSpec(specs: string) {
+  const nameMatch = specs.match(/^([a-zA-Z0-9_-]+)/);
+
+  if (!nameMatch) {
+    return null;
+  }
+
+  const packageName = nameMatch[1];
+  return packageName;
+}

--- a/packages/mambajs/src/solverpip.ts
+++ b/packages/mambajs/src/solverpip.ts
@@ -4,7 +4,8 @@ import { parse } from 'yaml';
 import {
   ILogger,
   ISolvedPackage,
-  ISolvedPackages
+  ISolvedPackages,
+  packageNameFromSpec
 } from '@emscripten-forge/mambajs-core';
 
 interface ISpec {
@@ -88,13 +89,10 @@ function resolveVersion(availableVersions: string[], constraint: string) {
 }
 
 function parsePyPiRequirement(requirement: string): ISpec | null {
-  const nameMatch = requirement.match(/^([a-zA-Z0-9_-]+)/);
-
-  if (!nameMatch) {
+  const packageName = packageNameFromSpec(requirement);
+  if (!packageName) {
     return null;
   }
-
-  const packageName = nameMatch[1];
 
   return {
     package: packageName,


### PR DESCRIPTION
We often need to use a spec name in different places, so the method `packageNameFromSpec` allows us to get it.