### PR TITLE
Fix package removal for empty directories

### DIFF
--- a/packages/mambajs-core/src/helper.ts
+++ b/packages/mambajs-core/src/helper.ts
@@ -204,6 +204,24 @@ export function saveFilesIntoEmscriptenFS(
   }
 }
 
+/**
+ * Recursive function that removes parent directories if they are empty
+ */
+function removeParentDirIfEmpty(FS: any, path: string) {
+  const pathInfo = FS.analyzePath(path);
+
+  if (!pathInfo.exists) {
+    return;
+  }
+
+  // only contains . and ..
+  if (FS.readdir(path).length === 2) {
+    FS.rmdir(path);
+  }
+
+  removeParentDirIfEmpty(FS, pathInfo.parentPath);
+}
+
 export function removeFilesFromEmscriptenFS(
   FS: any,
   paths: any,
@@ -221,6 +239,8 @@ export function removeFilesFromEmscriptenFS(
         } else {
           FS.unlink(path);
         }
+
+        removeParentDirIfEmpty(FS, pathInfo.parentPath);
       } else {
         console.log(`Uninstall error: Path ${path} does not exist`);
       }


### PR DESCRIPTION
I had the case where I could still import `ipycanvas` after removing it, since empty directories were still around in the `site-packages/ipycanvas` folder, making it that module importable (even though there was nothing in it)

This PR fixes it, now ipycanvas is not importable after uninstall

![Screenshot From 2025-06-30 11-49-21](https://github.com/user-attachments/assets/95d59f38-4ff3-4d79-b5ec-346ea4d0215b)
