### PR TITLE
Reduce logs + fix function name typo (breaking change)

### DIFF
--- a/packages/mambajs-core/src/index.ts
+++ b/packages/mambajs-core/src/index.ts
@@ -381,7 +381,7 @@ export interface ILoadSharedLibsOptions {
 export async function loadShareLibs(
   options: ILoadSharedLibsOptions
 ): Promise<void[]> {
-  const { sharedLibs, prefix, Module, logger } = options;
+  const { sharedLibs, prefix, Module } = options;
 
   const sharedLibsLoad: Promise<void>[] = [];
 
@@ -389,7 +389,6 @@ export async function loadShareLibs(
     const packageShareLibs = sharedLibs[pkgName];
 
     if (packageShareLibs.length > 0) {
-      logger?.log(`Loading shared libraries from ${pkgName}`);
       sharedLibsLoad.push(
         loadDynlibsFromPackage(prefix, pkgName, packageShareLibs, Module)
       );


### PR DESCRIPTION
Reducing a bit the printed logs. The environment diff table should be enough. 
![Screenshot From 2025-07-01 16-01-15](https://github.com/user-attachments/assets/42c98b30-5ae2-479e-98ca-365eddd10a3a)
