### PR TITLE
Fix command line option check

### DIFF
--- a/packages/mambajs-core/src/parser.ts
+++ b/packages/mambajs-core/src/parser.ts
@@ -188,7 +188,7 @@ function getCondaRemoveCommandParameters(
   ];
 
   limits.map((option: string) => {
-    if (input.includes(option)) {
+    if (input === option) {
       throw new Error(`Unsupported option ${option}`);
     }
   });
@@ -450,7 +450,7 @@ function getPipSpecs(
   const specs: string[] = [];
 
   limits.map((option: string) => {
-    if (input.includes(option)) {
+    if (input === option) {
       throw new Error(`Unsupported option ${option}`);
     }
   });


### PR DESCRIPTION
This was resulting in e.g. `%conda remove xeus-python` to fail because it contains `-p`, this PR now checks for exact match