### PR TITLE
Fail if no channel is specified

### DIFF
--- a/packages/mambajs-core/src/helper.ts
+++ b/packages/mambajs-core/src/helper.ts
@@ -471,10 +471,7 @@ export function formatChannels(
   channels?: string[]
 ): Pick<ILock, 'channelInfo' | 'channels'> {
   if (!channels || !channels.length) {
-    return {
-      channelInfo: DEFAULT_CHANNELS_INFO,
-      channels: DEFAULT_CHANNELS
-    };
+    throw new Error('No channels specified');
   }
 
   const formattedChannels: Pick<ILock, 'channelInfo' | 'channels'> = {

--- a/unittests/tests/parser/test-parse-bang.ts
+++ b/unittests/tests/parser/test-parse-bang.ts
@@ -42,6 +42,7 @@ cmd = parse('!conda install package1');
 expect(cmd.commands[0].data.type).toEqual('conda');
 expect(cmd.commands[0].type).toEqual('install');
 expect((cmd.commands[0].data as IInstallationCommandOptions).specs).toEqual(['package1']);
+expect((cmd.commands[0].data as IInstallationCommandOptions).channels).toEqual([]);
 
 cmd = parse('!micromamba install package2');
 expect(cmd.commands[0].data.type).toEqual('conda');


### PR DESCRIPTION
Default channels should not be picked up automatically anymore. Users need to be specific about the channels they want to use.