### PR TITLE
Layout tables to fit maximum column widths

### DIFF
--- a/unittests/helpers.ts
+++ b/unittests/helpers.ts
@@ -8,7 +8,7 @@ export class TestLogger implements ILogger {
 
     const message = msg.join(' ');
     console.log('LOG --', message);
-    this.logs = [this.logs, message].join(' ');
+    this.logs.push(message);
   }
 
   error(...msg: any[]): void {
@@ -24,6 +24,6 @@ export class TestLogger implements ILogger {
   }
 
   warnings = '';
-  logs = '';
+  logs: string[] = [];
   errors = '';
 }

--- a/unittests/tests/format/test-format.ts
+++ b/unittests/tests/format/test-format.ts
@@ -1,0 +1,45 @@
+import { solve } from "../../../packages/mambajs/src";
+import { TestLogger } from "../../helpers";
+import { expect } from 'earl';
+
+const logger = new TestLogger();
+
+const yml = `
+channels:
+  - https://prefix.dev/emscripten-forge-dev
+  - https://prefix.dev/conda-forge
+dependencies:
+  - pandas
+  - xeus-python
+`;
+
+solve({ymlOrSpecs: yml, logger}).then(async result => {
+  // Test format of table output is correct in terms of columns aligned and number of
+  // spaces between columns.
+
+  // Find row matching start of "  Name"
+  const headerIndex = logger.logs.findIndex(line => line.startsWith("  Name"));
+  expect(headerIndex).toBeGreaterThanOrEqual(0);
+
+  const tableHeader = logger.logs[headerIndex];
+  const tableBody = logger.logs.slice(headerIndex+2)
+
+  const colIndices = ['Name', 'Version', 'Build', 'Channel'].map(m => tableHeader.indexOf(m));
+  const ncol = colIndices.length;
+
+  // Find minimum number of spaces between columns in table.
+  let nspaces = [Infinity, Infinity, Infinity, Infinity];
+  tableBody.forEach(line => {
+    for (let i = 0; i < ncol; i++) {
+      const item = line.slice(colIndices[i], i == ncol-1 ? -1 : colIndices[i+1]);
+      const match = item.match(/^[\w\-\.]+( *)/);  // Text/number/dash/dot followed by whitespace
+      expect(match).not.toBeNullish();
+      const nspace = match[1].length;
+      if (nspace < nspaces[i]) {
+        nspaces[i] = nspace;
+      }
+    }
+  })
+
+  expect(nspaces).toEqual([2, 2, 2, 0]);
+});


### PR DESCRIPTION
Tables written to a logger currently use a fixed `columnWidth` for alignment of columns. This PR changes the layout so that the width of each column is determined by the maximum width of the items in that column. It is based similar code used in `cockle`.

Examples of table layouts with this PR:
```
  Name                    Version  Build        Channel
------------------------------------------------------------------
  clang-resource-headers  20.1.8   hc286ada_0   emscripten-forge
  cppinterop              1.7.0    h2072262_7   emscripten-forge
  emscripten-abi          3.1.73   h267e887_12  emscripten-forge
  nlohmann_json           3.12.0   h2072262_0   emscripten-forge
  nlohmann_json-abi       3.12.0   h0f90c79_1   conda-forge
  xeus                    5.2.6    h2072262_0   emscripten-forge
  xeus-cpp                0.8.0    h2072262_0   emscripten-forge

  Name                Version           Build                 Channel
-----------------------------------------------------------------------------------
+ bqplot              0.12.37           pyhd8ed1ab_0          conda-forge
~ comm                0.2.3 -> 0.2.3    none -> pyhe01879c_0  PyPi -> conda-forge
~ ipycanvas           0.14.3 -> 0.14.3  none -> pyhcf101f3_0  PyPi -> conda-forge
~ ipywidgets          8.1.8 -> 8.1.8    none -> pyhd8ed1ab_0  PyPi -> conda-forge
~ jupyterlab_widgets  3.0.16 -> 3.0.16  none -> pyhcf101f3_1  PyPi -> conda-forge
+ pillow              12.1.0            py313hafe190e_0       emscripten-forge
+ traittypes          0.2.3             pyh332efcf_0          conda-forge
~ widgetsnbextension  4.0.15 -> 4.0.15  none -> pyhd8ed1ab_0  PyPi -> conda-forge
+ zlib                1.3.1             h4e94343_2            emscripten-forge
```
whereas before they were:
```
Name                          Version                       Build                         Channel
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
clang-resource-headers        20.1.8                        hc286ada_0                    emscripten-forge
cppinterop                    1.7.0                         h2072262_7                    emscripten-forge
emscripten-abi                3.1.73                        h267e887_12                   emscripten-forge
nlohmann_json                 3.12.0                        h2072262_0                    emscripten-forge
nlohmann_json-abi             3.12.0                        h0f90c79_1                    conda-forge
xeus                          5.2.6                         h2072262_0                    emscripten-forge
xeus-cpp                      0.8.0                         h2072262_0                    emscripten-forge

  Name                          Version                       Build                         Channel
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ bqplot                        0.12.37                       pyhd8ed1ab_0                  conda-forge
~ comm                          0.2.3 -> 0.2.3                none -> pyhe01879c_0          PyPi -> conda-forge
~ ipycanvas                     0.14.3 -> 0.14.3              none -> pyhcf101f3_0          PyPi -> conda-forge
~ ipywidgets                    8.1.8 -> 8.1.8                none -> pyhd8ed1ab_0          PyPi -> conda-forge
~ jupyterlab_widgets            3.0.16 -> 3.0.16              none -> pyhcf101f3_1          PyPi -> conda-forge
+ pillow                        12.1.0                        py313hafe190e_0               emscripten-forge
+ traittypes                    0.2.3                         pyh332efcf_0                  conda-forge
~ widgetsnbextension            4.0.15 -> 4.0.15              none -> pyhd8ed1ab_0          PyPi -> conda-forge
+ zlib                          1.3.1                         h4e94343_2                    emscripten-forge
```
Colours are correctly supported in that they are displayed in colour but the ANSI sequences used to specify those colours do not contribute to column widths. They are not shown above (github does not display them in PR comments) but will be correct in CI - I will post a link when CI runs.

Note the 2 spaces at the start of each row of the first table shown which is different to before but consistent with what `micromamba` does.

A new test is included.