### PR TITLE
Limit solving time precision to 3 decimal places

### DIFF
--- a/packages/mambajs/src/solver.ts
+++ b/packages/mambajs/src/solver.ts
@@ -132,7 +132,7 @@ export const solveConda = async (options: ISolveOptions): Promise<ILock> => {
     const endSolveTime = performance.now();
     if (logger) {
       logger.log(
-        `Solving took ${(endSolveTime - startSolveTime) / 1000} seconds`
+        `Solving took ${((endSolveTime - startSolveTime) / 1000).toFixed(3)} seconds`
       );
     }
 

--- a/unittests/tests/mixed/test-solver.ts
+++ b/unittests/tests/mixed/test-solver.ts
@@ -38,4 +38,8 @@ solve({ymlOrSpecs: yml, logger}).then(async result => {
 
   expect(condaPackages['ipycanvas'].version).toEqual('0.13.2');
   expect(pipPackages['bqplot'].version).toEqual('0.12.42');
+
+  const matches = logger.logs.filter(line => line.startsWith('Solving took'));
+  expect(matches).toHaveLength(1);
+  expect(matches[0]).toMatchRegex(/^Solving took \d+\.\d{3} seconds$/);
 });


### PR DESCRIPTION
Sometimes I see the solving time displayed with very high precision such as
```
Solving took 0.43510233299999984 seconds
```
which may be browser and/or OS specific behaviour (I am using chrome on macOS).

This PR limits the displayed solving time to 3 decimal places, the nearest millisecond, such as
```
Solving took 0.435 seconds
```